### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,11 +5,11 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.3.1
-RUFF_VERSION=0.15.12
+RUFF_VERSION=0.15.13
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
-MYPY_VERSION=2.0.0
+MYPY_VERSION=2.1.0
 PYTEST_VERSION=9.0.3
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.13.5
+COVERAGE_VERSION=7.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
 dev = [
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
-    "ruff>=0.15.12",
-    "mypy==2.0.0",
+    "ruff>=0.15.13",
+    "mypy>=2.1.0",
     "black==26.3.1",
 ]
 


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 2 version updates:
  - ruff: >=0.15.12 -> >=0.15.13
  - mypy: ==2.0.0 -> >=2.1.0

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`