### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -827,7 +827,7 @@ function main() {
   const markdownSummary = formatBotCommentAuthCoverageMarkdown(report);
   fs.writeFileSync(options.output, `${JSON.stringify(report, null, 2)}\n`);
   fs.writeFileSync(options.markdown, markdownSummary);
-  process.stdout.write(markdownSummary);
+  fs.writeFileSync(process.stdout.fd, markdownSummary);
   return report.status === 'fail' ? 1 : 0;
 }
 

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -113,7 +113,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -270,9 +270,19 @@ jobs:
         with:
           script: |
             const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH || process.env.GITHUB_WORKSPACE;
-            const { createTokenAwareRetry } = require(
-              `${scriptsPath}/.github/scripts/github-api-with-retry.js`
-            );
+            const retryHelpers = require(`${scriptsPath}/.github/scripts/github-api-with-retry.js`);
+            const { createTokenAwareRetry } = retryHelpers;
+            const isRateLimitError = retryHelpers.isRateLimitError || ((error) => {
+              const status = error?.status || error?.response?.status;
+              const message = String(
+                error?.message || error?.response?.data?.message || '',
+              ).toLowerCase();
+              const headers = error?.response?.headers || error?.headers || {};
+              const remaining = parseInt(headers['x-ratelimit-remaining'], 10);
+              return status === 429 ||
+                (status === 403 && message.includes('rate limit')) ||
+                (Number.isFinite(remaining) && remaining <= 0);
+            });
             const { withRetry, paginateWithRetry } = await createTokenAwareRetry({
               github,
               core,
@@ -281,6 +291,26 @@ jobs:
             });
 
             let issueNumber, issue, pr;
+            const deferForRateLimit = (stage, error) => {
+              if (!isRateLimitError(error)) {
+                return false;
+              }
+              core.warning(
+                `Auto-pilot determine context deferred during ${stage}: ${error.message}`,
+              );
+              if (issueNumber) {
+                core.setOutput('issue_number', issueNumber);
+              }
+              if (issue?.title) {
+                core.setOutput('issue_title', issue.title);
+              }
+              if (issue?.state) {
+                core.setOutput('issue_state', issue.state);
+              }
+              core.setOutput('should_continue', 'false');
+              core.setOutput('reason', 'rate-limited');
+              return true;
+            };
 
             // Get issue number from various sources (in priority order)
             if (context.eventName === 'workflow_dispatch') {
@@ -319,14 +349,19 @@ jobs:
 
             // Fetch issue if not in payload (with retry)
             if (!issue) {
-              const { data } = await withRetry(() =>
-                github.rest.issues.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issueNumber
-                })
-              );
-              issue = data;
+              try {
+                const { data } = await withRetry((client) =>
+                  client.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber
+                  })
+                );
+                issue = data;
+              } catch (error) {
+                if (deferForRateLimit('issue fetch', error)) return;
+                throw error;
+              }
             }
 
             const labels = issue.labels.map(l => l.name);
@@ -367,15 +402,21 @@ jobs:
             // Check for actual optimizer output (not just label)
             // Since we run optimizer inline now, this should always exist after optimize step
             // the optimizer workflow actually completed its work
-            const comments = await paginateWithRetry(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                per_page: 100
-              }
-            );
+            let comments = [];
+            try {
+              comments = await paginateWithRetry(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  per_page: 100
+                }
+              );
+            } catch (error) {
+              if (deferForRateLimit('optimizer comment scan', error)) return;
+              throw error;
+            }
 
             const hasOptimizerOutput = comments.some(c => {
               const body = c.body || '';
@@ -385,15 +426,21 @@ jobs:
             });
 
             // Check for linked PR (with pagination and multiple event types)
-            const timelineEvents = await paginateWithRetry(
-              github.rest.issues.listEventsForTimeline,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                per_page: 100
-              }
-            );
+            let timelineEvents = [];
+            try {
+              timelineEvents = await paginateWithRetry(
+                github.rest.issues.listEventsForTimeline,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  per_page: 100
+                }
+              );
+            } catch (error) {
+              if (deferForRateLimit('timeline scan', error)) return;
+              throw error;
+            }
 
             function matchesIssueReference(text, num) {
               if (!text) return false;
@@ -453,22 +500,44 @@ jobs:
         with:
           script: |
             const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH || process.env.GITHUB_WORKSPACE;
-            const { paginateWithRetry } = require(
-              `${scriptsPath}/.github/scripts/github-api-with-retry.js`
-            );
+            const retryHelpers = require(`${scriptsPath}/.github/scripts/github-api-with-retry.js`);
+            const { paginateWithRetry } = retryHelpers;
+            const isRateLimitError = retryHelpers.isRateLimitError || ((error) => {
+              const status = error?.status || error?.response?.status;
+              const message = String(
+                error?.message || error?.response?.data?.message || '',
+              ).toLowerCase();
+              const headers = error?.response?.headers || error?.headers || {};
+              const remaining = parseInt(headers['x-ratelimit-remaining'], 10);
+              return status === 429 ||
+                (status === 403 && message.includes('rate limit')) ||
+                (Number.isFinite(remaining) && remaining <= 0);
+            });
             const issueNumber = parseInt(process.env.ISSUE_NUMBER);
 
             // Get all comments to count auto-pilot steps (with pagination and retry)
-            const allComments = await paginateWithRetry(
-              github,
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                per_page: 100
+            let allComments = [];
+            try {
+              allComments = await paginateWithRetry(
+                github,
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  per_page: 100
+                }
+              );
+            } catch (error) {
+              if (!isRateLimitError(error)) {
+                throw error;
               }
-            );
+              core.warning(`Auto-pilot step count deferred by rate limit: ${error.message}`);
+              core.setOutput('exceeded', 'false');
+              core.setOutput('count', '0');
+              core.setOutput('rate_limited', 'true');
+              return;
+            }
 
             const stepComments = allComments.filter(c =>
               typeof c.body === 'string' && c.body.includes('🤖 Auto-pilot step')
@@ -485,6 +554,7 @@ jobs:
 
             core.setOutput('exceeded', 'false');
             core.setOutput('count', stepCount.toString());
+            core.setOutput('rate_limited', 'false');
 
       - name: Stop if exceeded
         if: steps.cycles.outputs.exceeded == 'true'
@@ -533,7 +603,8 @@ jobs:
       - name: Determine next step
         if: |
           steps.context.outputs.should_continue == 'true' &&
-          steps.cycles.outputs.exceeded != 'true'
+          steps.cycles.outputs.exceeded != 'true' &&
+          steps.cycles.outputs.rate_limited != 'true'
         id: next
         env:
           FORCE_STEP: ${{ inputs.force_step }}
@@ -653,7 +724,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGCHAIN_TRACING_V2: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
+          LANGCHAIN_PROJECT: workflows-agents
           PYTHONPATH: ${{ github.workspace }}
+          ISSUE_PR_CONTEXT_WORKFLOW: agents-auto-pilot
         run: |
 
           # Post progress comment
@@ -744,6 +819,17 @@ jobs:
               sys.exit(1)
           with open('/tmp/formatted_body.md', 'w') as f:
               f.write(formatted)
+          def env_value(value):
+              return str(value or '').replace('\r', '').replace('\n', '').strip()
+
+          trace_id = env_value(result.get('langsmith_trace_id'))
+          trace_url = env_value(result.get('langsmith_trace_url'))
+          if trace_id or trace_url:
+              with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as env_file:
+                  if trace_id:
+                      env_file.write(f'AUTOPILOT_FORMAT_LANGSMITH_TRACE_ID={trace_id}\n')
+                  if trace_url:
+                      env_file.write(f'AUTOPILOT_FORMAT_LANGSMITH_TRACE_URL={trace_url}\n')
           print('Issue formatted successfully')
           " || exit 1
 
@@ -872,6 +958,8 @@ jobs:
           AUTOPILOT_STEP_NAME: format
           AUTOPILOT_ERROR_CATEGORY: metrics-collector
           AUTOPILOT_METRICS_LOG_PATH: ${{ env.AUTOPILOT_METRICS_LOG_PATH }}
+          LANGSMITH_TRACE_ID: ${{ env.AUTOPILOT_FORMAT_LANGSMITH_TRACE_ID || '' }}
+          LANGSMITH_TRACE_URL: ${{ env.AUTOPILOT_FORMAT_LANGSMITH_TRACE_URL || '' }}
         run: |
           success="${{ steps.format_step.outcome == 'success' }}"
           failure_reason="none"
@@ -904,9 +992,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGCHAIN_TRACING_V2: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
+          LANGCHAIN_PROJECT: workflows-agents
           LANGCHAIN_PROVIDER: anthropic
           LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
           PYTHONPATH: ${{ github.workspace }}
+          ISSUE_PR_CONTEXT_WORKFLOW: agents-auto-pilot
         run: |
 
           # Post progress comment
@@ -992,6 +1084,30 @@ jobs:
                   f.write(reason)
               sys.exit(0)
           "
+
+          python - <<'PY'
+          import json
+          import os
+
+          try:
+              with open('/tmp/suggestions.json', encoding='utf-8') as handle:
+                  data = json.load(handle)
+          except Exception:
+              data = {}
+
+          def env_value(value):
+              return str(value or '').replace('\r', '').replace('\n', '').strip()
+
+          env_path = os.environ.get('GITHUB_ENV')
+          if env_path:
+              trace_id = env_value(data.get('langsmith_trace_id'))
+              trace_url = env_value(data.get('langsmith_trace_url'))
+              with open(env_path, 'a', encoding='utf-8') as env_file:
+                  if trace_id:
+                      env_file.write(f"AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_ID={trace_id}\n")
+                  if trace_url:
+                      env_file.write(f"AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_URL={trace_url}\n")
+          PY
 
           # If guard blocked, apply needs-human + pause labels and stop
           if [ -f /tmp/guard_blocked ]; then
@@ -1148,6 +1264,8 @@ jobs:
           AUTOPILOT_ERROR_CATEGORY: metrics-collector
           AUTOPILOT_METRICS_LOG_PATH: ${{ env.AUTOPILOT_METRICS_LOG_PATH }}
         run: |
+          export LANGSMITH_TRACE_ID="${AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_ID:-}"
+          export LANGSMITH_TRACE_URL="${AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_URL:-}"
           success="${{ steps.optimize_step.outcome == 'success' }}"
           failure_reason="none"
           if [ "$success" != "true" ]; then
@@ -1258,9 +1376,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGCHAIN_TRACING_V2: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
+          LANGCHAIN_PROJECT: workflows-agents
           LANGCHAIN_PROVIDER: anthropic
           LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
           PYTHONPATH: ${{ github.workspace }}
+          ISSUE_PR_CONTEXT_WORKFLOW: agents-auto-pilot
         run: |
 
           # Post progress comment
@@ -1336,6 +1458,7 @@ jobs:
           # Extract and apply suggestions
           python -c "
           import json
+          import os
           import sys
           import re
           sys.path.insert(0, 'scripts/langchain')
@@ -1362,6 +1485,19 @@ jobs:
 
           # Apply suggestions
           result = apply_suggestions(issue_body, suggestions, use_llm=True)
+
+          def env_value(value):
+              return str(value or '').replace('\r', '').replace('\n', '').strip()
+
+          env_path = os.environ.get('GITHUB_ENV')
+          if env_path:
+              trace_id = env_value(result.get('langsmith_trace_id'))
+              trace_url = env_value(result.get('langsmith_trace_url'))
+              with open(env_path, 'a', encoding='utf-8') as env_file:
+                  if trace_id:
+                      env_file.write(f'AUTOPILOT_APPLY_LANGSMITH_TRACE_ID={trace_id}\n')
+                  if trace_url:
+                      env_file.write(f'AUTOPILOT_APPLY_LANGSMITH_TRACE_URL={trace_url}\n')
 
           # Check for guard_blocked
           if result.get('guard_blocked'):
@@ -1504,6 +1640,8 @@ jobs:
           AUTOPILOT_ERROR_CATEGORY: metrics-collector
           AUTOPILOT_METRICS_LOG_PATH: ${{ env.AUTOPILOT_METRICS_LOG_PATH }}
         run: |
+          export LANGSMITH_TRACE_ID="${AUTOPILOT_APPLY_LANGSMITH_TRACE_ID:-}"
+          export LANGSMITH_TRACE_URL="${AUTOPILOT_APPLY_LANGSMITH_TRACE_URL:-}"
           success="${{ steps.apply_step.outcome == 'success' }}"
           failure_reason="none"
           if [ "$success" != "true" ]; then
@@ -1754,6 +1892,10 @@ jobs:
             const runnerOverride = issueLabels
               .map((label) => toLabelName(label).toLowerCase())
               .find((name) => name.startsWith('runner:'));
+            const runnerOverrideKey = runnerOverride
+              ? runnerOverride.slice('runner:'.length).trim().toLowerCase()
+              : '';
+            let warnedAboutRunnerOverride = false;
 
             try {
               const registryLib = require('./.github/scripts/agent_registry.js');
@@ -1764,6 +1906,23 @@ jobs:
 
               if (Array.isArray(issueLabels) && issueLabels.length) {
                 const knownAgents = new Set(Object.keys(registry.agents || {}));
+                knownAgents.add('auto');
+                const runnerOverrideResolver = () => {
+                  if (!runnerOverrideKey) {
+                    return null;
+                  }
+                  if (!knownAgents.has(runnerOverrideKey)) {
+                    if (!warnedAboutRunnerOverride) {
+                      core.warning(
+                        `Ignoring runner override label ${runnerOverride} because ` +
+                          `${runnerOverrideKey || '(empty)'} is not a registered agent.`,
+                      );
+                      warnedAboutRunnerOverride = true;
+                    }
+                    return null;
+                  }
+                  return runnerOverrideKey;
+                };
                 recognizedAgentLabels = issueLabels
                   .map((label) => {
                     const normalized = toLabelName(label).toLowerCase();
@@ -1783,9 +1942,9 @@ jobs:
                   ? recognizedAgentLabels.map(({ normalized }) => normalized)
                   : issueLabels;
 
-                if (runnerOverride) {
-                  const runnerKey = runnerOverride.slice('runner:'.length).trim();
-                  agentKey = runnerKey || defaultAgent;
+                const overrideKey = runnerOverrideResolver();
+                if (overrideKey) {
+                  agentKey = overrideKey;
                 } else if (routingLabels.length) {
                   try {
                     agentKey =
@@ -1806,9 +1965,18 @@ jobs:
                 } else {
                   agentKey = defaultAgent;
                 }
-              } else if (runnerOverride) {
-                const runnerKey = runnerOverride.slice('runner:'.length).trim();
-                agentKey = runnerKey || defaultAgent;
+              } else if (runnerOverrideKey) {
+                const knownAgents = new Set(Object.keys(registry.agents || {}));
+                knownAgents.add('auto');
+                if (knownAgents.has(runnerOverrideKey)) {
+                  agentKey = runnerOverrideKey;
+                } else {
+                  core.warning(
+                    `Ignoring runner override label ${runnerOverride} because ` +
+                      `${runnerOverrideKey || '(empty)'} is not a registered agent.`,
+                  );
+                  agentKey = defaultAgent;
+                }
               } else {
                 agentKey = defaultAgent;
               }
@@ -2170,6 +2338,38 @@ jobs:
             let issueLabels = [];
             let branchPrefix = 'codex/issue-';
 
+            const dispatchFirstAvailableWorkflow = async ({
+              workflowIds,
+              prNumber,
+              inputs,
+              description
+            }) => {
+              const failures = [];
+              for (const workflowId of workflowIds) {
+                try {
+                  await withRetry((client) => client.rest.actions.createWorkflowDispatch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: workflowId,
+                    ref: baseBranch,
+                    inputs
+                  }));
+                  core.info(`Dispatched ${description} via ${workflowId} for PR #${prNumber}`);
+                  return workflowId;
+                } catch (dispatchError) {
+                  const status = dispatchError?.status;
+                  const message = dispatchError?.message || String(dispatchError);
+                  failures.push(`${workflowId}: ${message}`);
+                  if (status !== 404) {
+                    break;
+                  }
+                  core.info(`Workflow ${workflowId} not found; trying fallback`);
+                }
+              }
+              core.warning(`Could not dispatch ${description}: ${failures.join('; ')}`);
+              return null;
+            };
+
             const toLabelName = (label) => {
               if (!label) return '';
               if (typeof label === 'string') return label;
@@ -2221,12 +2421,37 @@ jobs:
               const runnerOverride = issueLabels
                 .map((label) => toLabelName(label).toLowerCase())
                 .find((name) => name.startsWith('runner:'));
+              const runnerOverrideKey = runnerOverride
+                ? runnerOverride.slice('runner:'.length).trim().toLowerCase()
+                : '';
+              let warnedAboutRunnerOverride = false;
 
               let recognizedAgentLabels = [];
+              let runnerOverrideResolver = null;
               if (Array.isArray(issueLabels) && issueLabels.length) {
                 const knownAgents = new Set(Object.keys(registry.agents || {}));
+                knownAgents.add('auto');
+                runnerOverrideResolver = () => {
+                  if (!runnerOverrideKey) {
+                    return null;
+                  }
+                  if (!knownAgents.has(runnerOverrideKey)) {
+                    if (!warnedAboutRunnerOverride) {
+                      core.warning(
+                        `Ignoring runner override label ${runnerOverride} because ` +
+                          `${runnerOverrideKey || '(empty)'} is not a registered agent.`,
+                      );
+                      warnedAboutRunnerOverride = true;
+                    }
+                    return null;
+                  }
+                  return runnerOverrideKey;
+                };
                 recognizedAgentLabels = issueLabels
-                  .map((label) => toLabelName(label).toLowerCase())
+                  .map((label) => {
+                    const normalized = toLabelName(label).toLowerCase();
+                    return normalized;
+                  })
                   .filter((normalized) => normalized.startsWith('agent:'))
                   .filter((normalized) => {
                     const suffix = normalized.slice('agent:'.length);
@@ -2241,16 +2466,37 @@ jobs:
                 ? recognizedAgentLabels
                 : issueLabels;
 
-              if (runnerOverride) {
-                const runnerKey = runnerOverride.slice('runner:'.length).trim();
-                agentKey = runnerKey || defaultAgent;
-                } else if (routingLabels.length) {
-                  try {
-                    agentKey =
-                      resolveAgentFromLabels(
-                        routingLabels,
-                        { registryPath: './.github/agents/registry.yml' },
-                      ) || defaultAgent;
+              const overrideKeyResolver = () => {
+                if (!runnerOverrideKey) {
+                  return null;
+                }
+                const knownAgents = new Set(Object.keys(registry.agents || {}));
+                knownAgents.add('auto');
+                if (!knownAgents.has(runnerOverrideKey)) {
+                  if (!warnedAboutRunnerOverride) {
+                    core.warning(
+                      `Ignoring runner override label ${runnerOverride} because ` +
+                        `${runnerOverrideKey || '(empty)'} is not a registered agent.`,
+                    );
+                    warnedAboutRunnerOverride = true;
+                  }
+                  return null;
+                }
+                return runnerOverrideKey;
+              };
+              const overrideKey = runnerOverrideResolver
+                ? runnerOverrideResolver()
+                : overrideKeyResolver();
+
+              if (overrideKey) {
+                agentKey = overrideKey;
+              } else if (routingLabels.length) {
+                try {
+                  agentKey =
+                    resolveAgentFromLabels(
+                      routingLabels,
+                      { registryPath: './.github/agents/registry.yml' },
+                    ) || defaultAgent;
                 } catch (resolveError) {
                   const resolveContext = resolveError?.message || resolveError;
                   core.warning(
@@ -2434,15 +2680,18 @@ jobs:
                   ? ' Re-dispatched belt dispatcher.'
                   : '';
                 core.info(`Applying branch-creation backoff: waiting ${actualMinutes} minutes`);
+                const backoffBody = [
+                  `🤖 **Auto-pilot**: Backoff delay (${actualMinutes}m)`,
+                  '',
+                  `Branch not created yet. Attempt ${stallCount + 1}/${maxStallRetries}.` +
+                    redispatchNote,
+                  'Waiting before retry...',
+                ].join('\n');
                 await withRetry((client) => client.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issueNumber,
-                    body: `🤖 **Auto-pilot**: Backoff delay (${actualMinutes}m)
-
-                    Branch not created yet.
-                    Attempt ${stallCount + 1}/${maxStallRetries}.${redispatchNote}
-                    Waiting before retry...`
+                  body: backoffBody,
                 }));
 
                 // Sleep with exponential backoff
@@ -2689,11 +2938,15 @@ jobs:
             core.info(`Creating PR from ${branchName}`);
 
             // Fetch issue body to include in PR
+            const { buildIssueContext } = require('./.github/scripts/issue_context_utils.js');
             const { data: issue } = await withRetry((client) => client.rest.issues.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber
             }));
+            const issueContext = buildIssueContext(issue.body || '', {
+              downstreamWorkflow: 'agents-auto-pilot',
+            });
 
             const prTitle = `[Auto-pilot] ${issueTitle}`;
             const prBody = [
@@ -2701,7 +2954,7 @@ jobs:
               '',
               `Closes #${issueNumber}`,
               '',
-              issue.body || ''
+              issueContext.formattedBody || issue.body || ''
             ].join('\n');
 
             try {
@@ -2736,41 +2989,28 @@ jobs:
                 ? `✅ Added labels: \`agent:${agentKey}\`, \`agents:keepalive\`, \`autofix\``
                 : '⚠️ Could not add labels (add manually)';
 
-              // Dispatch PR event hub to build Automated Status Summary
+              // Dispatch PR meta workflow to build Automated Status Summary
               // (GITHUB_TOKEN actions do not trigger workflow runs automatically)
-              try {
-                await withRetry((client) => client.rest.actions.createWorkflowDispatch({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'agents-80-pr-event-hub.yml',
-                  ref: baseBranch,
-                  inputs: {
-                    pr_number: pr.number.toString(),
-                    handler: 'pr-meta',
-                    debug: 'false'
-                  }
-                }));
-                core.info(`Dispatched PR event hub update for PR #${pr.number}`);
-              } catch (dispatchError) {
-                core.warning(`Could not dispatch PR event hub update: ${dispatchError?.message}`);
-              }
+              await dispatchFirstAvailableWorkflow({
+                workflowIds: ['agents-80-pr-event-hub.yml', 'agents-pr-meta-v4.yml'],
+                prNumber: pr.number,
+                description: 'PR meta update',
+                inputs: {
+                  pr_number: pr.number.toString(),
+                  debug: 'false'
+                }
+              });
 
-              // Dispatch gate followups workflow since GITHUB_TOKEN labels don't trigger it
-              try {
-                await withRetry((client) => client.rest.actions.createWorkflowDispatch({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'agents-81-gate-followups.yml',
-                  ref: baseBranch,
-                  inputs: {
-                    pr_number: pr.number.toString(),
-                    force_retry: 'true'
-                  }
-                }));
-                core.info(`Dispatched gate followups for PR #${pr.number}`);
-              } catch (dispatchError) {
-                core.warning(`Could not dispatch gate followups: ${dispatchError?.message}`);
-              }
+              // Dispatch keepalive workflow since GITHUB_TOKEN labels don't trigger it
+              await dispatchFirstAvailableWorkflow({
+                workflowIds: ['agents-81-gate-followups.yml', 'agents-keepalive-loop.yml'],
+                prNumber: pr.number,
+                description: 'keepalive follow-up',
+                inputs: {
+                  pr_number: pr.number.toString(),
+                  force_retry: 'true'
+                }
+              });
 
               // Add PR link comment to the issue with full URL for visibility
               // Use GITHUB_SERVER_URL for GHES/AE compatibility instead of hardcoding github.com

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -416,6 +416,47 @@ def _safe_int(value: Any) -> int | None:
         return None
 
 
+def _langsmith_trace_refs(entry: dict[str, Any]) -> set[str]:
+    trace_refs: set[str] = set()
+    trace_id = str(entry.get("langsmith_trace_id") or "").strip()
+    trace_url = str(entry.get("langsmith_trace_url") or "").strip()
+    if trace_id:
+        trace_refs.add(f"id:{trace_id}")
+    elif trace_url:
+        trace_refs.add(f"url:{trace_url}")
+    traces = entry.get("langsmith_traces")
+    if isinstance(traces, list):
+        for item in traces:
+            if not isinstance(item, dict):
+                continue
+            item_trace_id = str(
+                item.get("trace_id") or item.get("langsmith_trace_id") or ""
+            ).strip()
+            item_trace_url = str(
+                item.get("trace_url") or item.get("langsmith_trace_url") or ""
+            ).strip()
+            if item_trace_id:
+                trace_refs.add(f"id:{item_trace_id}")
+            elif item_trace_url:
+                trace_refs.add(f"url:{item_trace_url}")
+    return trace_refs
+
+
+def _langsmith_trace_count(entry: dict[str, Any]) -> int:
+    return len(_langsmith_trace_refs(entry))
+
+
+def _verifier_run_key(entry: dict[str, Any], index: int) -> str:
+    run_id = entry.get("run_id") or entry.get("workflow_run_id")
+    run_attempt = entry.get("run_attempt")
+    pr_number_for_key = _safe_int(entry.get("pr_number") or entry.get("pr"))
+    if run_id:
+        return f"run:{run_id}:attempt:{run_attempt or ''}"
+    if pr_number_for_key is not None:
+        return f"pr:{pr_number_for_key}"
+    return f"entry:{index}"
+
+
 def _unsupported_verifier_models() -> set[str]:
     raw = ""
     for env_name in (
@@ -592,19 +633,15 @@ def _summarise_verifier(
     issues_created = 0
     acceptance_counts: list[int] = []
     terminal_records = 0
+    langsmith_traced_run_keys: set[str] = set()
+    langsmith_trace_refs_by_run_key: dict[str, set[str]] = {}
     for index, entry in enumerate(entries):
         is_terminal_disposition = entry.get("schema") == "workflows-terminal-disposition/v1"
         is_verifier_terminal = _is_verifier_terminal_entry(entry)
+        verifier_run_key = None
         if not is_terminal_disposition:
-            run_id = entry.get("run_id") or entry.get("workflow_run_id")
-            run_attempt = entry.get("run_attempt")
-            pr_number_for_key = _safe_int(entry.get("pr_number") or entry.get("pr"))
-            if run_id:
-                verifier_run_keys.add(f"run:{run_id}:attempt:{run_attempt or ''}")
-            elif pr_number_for_key is not None:
-                verifier_run_keys.add(f"pr:{pr_number_for_key}")
-            else:
-                verifier_run_keys.add(f"entry:{index}")
+            verifier_run_key = _verifier_run_key(entry, index)
+            verifier_run_keys.add(verifier_run_key)
 
         verdict = entry.get("verdict")
         if verdict:
@@ -662,6 +699,10 @@ def _summarise_verifier(
         acceptance = _safe_int(entry.get("acceptance_criteria_count"))
         if acceptance is not None:
             acceptance_counts.append(acceptance)
+        trace_refs = _langsmith_trace_refs(entry)
+        if trace_refs and verifier_run_key:
+            langsmith_traced_run_keys.add(verifier_run_key)
+            langsmith_trace_refs_by_run_key.setdefault(verifier_run_key, set()).update(trace_refs)
     for entry in ledger_entries or []:
         disposition = str(entry.get("disposition") or "unknown")
         ledger_dispositions[disposition] += 1
@@ -695,6 +736,10 @@ def _summarise_verifier(
         "verdicts": verdicts,
         "issues_created": issues_created,
         "avg_acceptance": avg_acceptance,
+        "langsmith_trace_records": len(langsmith_traced_run_keys),
+        "langsmith_trace_count": sum(
+            len(trace_refs) for trace_refs in langsmith_trace_refs_by_run_key.values()
+        ),
         "terminal_records": terminal_records,
         "terminal_dispositions": terminal_dispositions,
         "terminal_sources": terminal_sources,
@@ -735,8 +780,15 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
     cycle_steps_completed = 0
     escalation_count = 0
     needs_human_count = 0
+    langsmith_trace_records = 0
+    langsmith_trace_count = 0
 
     for entry in entries:
+        trace_count = _langsmith_trace_count(entry)
+        if trace_count:
+            langsmith_trace_records += 1
+            langsmith_trace_count += trace_count
+
         issue_num = _safe_int(entry.get("issue_number") or entry.get("issue"))
         if issue_num is not None:
             issues.add(issue_num)
@@ -803,6 +855,8 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
         "escalation_count": escalation_count,
         "escalation_reasons": escalation_reasons,
         "needs_human_count": needs_human_count,
+        "langsmith_trace_records": langsmith_trace_records,
+        "langsmith_trace_count": langsmith_trace_count,
     }
 
 
@@ -1268,6 +1322,11 @@ def build_summary(
             f"- Verdicts: {_format_counter(verifier['verdicts'])}",
             f"- Issues created: {verifier['issues_created']}",
             f"- Avg acceptance criteria: {verifier['avg_acceptance']:.1f}",
+            (
+                "- LangSmith trace coverage: "
+                f"{_format_rate(verifier['langsmith_trace_records'], verifier['runs'])}"
+                f" ({verifier['langsmith_trace_count']} traces)"
+            ),
             f"- Terminal disposition records: {verifier['terminal_records']}",
             f"- Terminal dispositions: {_format_counter(verifier['terminal_dispositions'])}",
             f"- Terminal disposition sources: {_format_counter(verifier['terminal_sources'])}",
@@ -1342,6 +1401,11 @@ def build_summary(
                 f"- Records: {autopilot['records']}",
                 f"- Issues: {autopilot['issues']}",
                 f"- Total step executions: {autopilot['total_steps']}",
+                (
+                    "- LangSmith trace coverage: "
+                    f"{_format_rate(autopilot['langsmith_trace_records'], autopilot['records'])}"
+                    f" ({autopilot['langsmith_trace_count']} traces)"
+                ),
                 f"- Cycle records: {autopilot['cycle_records']}",
                 f"- Cycle count distribution: {_format_counter(autopilot['cycle_counts'])}",
                 (

--- a/scripts/langchain/context_extractor.py
+++ b/scripts/langchain/context_extractor.py
@@ -18,8 +18,10 @@ from pathlib import Path
 
 try:
     from scripts.langchain.issue_pr_context import ContextOptions, build_issue_context
+    from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
 except ModuleNotFoundError:
     from issue_pr_context import ContextOptions, build_issue_context
+    from trace_utils import TraceInfo, invoke_with_trace
 
 CONTEXT_EXTRACTOR_PROMPT = """
 From this issue and related discussion, extract:
@@ -260,12 +262,15 @@ def extract_context(
                 prompt = _load_prompt()
                 template = ChatPromptTemplate.from_template(prompt)
                 chain = template | client
+                trace = TraceInfo()
                 try:
-                    response = chain.invoke(
+                    response, trace = invoke_with_trace(
+                        chain,
                         {
                             "issue_body": issue_body,
                             "comments": "\n\n".join(comments) if comments else "_None._",
-                        }
+                        },
+                        operation="context_extractor",
                     )
                 except Exception as e:
                     # If GitHub Models fails with 401, retry with OpenAI
@@ -274,22 +279,26 @@ def extract_context(
                         if fallback_info:
                             client, provider = fallback_info
                             chain = template | client
-                            response = chain.invoke(
+                            response, trace = invoke_with_trace(
+                                chain,
                                 {
                                     "issue_body": issue_body,
                                     "comments": "\n\n".join(comments) if comments else "_None._",
-                                }
+                                },
+                                operation="context_extractor",
                             )
                         else:
                             raise
                     else:
                         raise
                 content = (getattr(response, "content", None) or str(response)).strip()
-                return {
+                result = {
                     "context_section": content,
                     "provider_used": provider,
                     "used_llm": True,
                 }
+                result.update(trace.as_dict())
+                return result
 
     return {
         "context_section": _fallback_extract(issue_body, comments),

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -20,9 +20,11 @@ from typing import Any
 try:
     from scripts.langchain.injection_guard import check_prompt_injection
     from scripts.langchain.issue_pr_context import ContextOptions, build_issue_context
+    from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
 except ImportError:  # pragma: no cover - fallback for direct invocation
     from injection_guard import check_prompt_injection
     from issue_pr_context import ContextOptions, build_issue_context
+    from trace_utils import TraceInfo, invoke_with_trace
 
 # Maximum issue body size to prevent OpenAI rate limit errors (30k TPM limit)
 # ~4 chars per token, so 50k chars ≈ 12.5k tokens, leaving headroom for prompt + output
@@ -506,8 +508,13 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
                 prompt = _load_prompt()
                 template = ChatPromptTemplate.from_template(prompt)
                 chain = template | client
+                trace = TraceInfo()
                 try:
-                    response = chain.invoke({"issue_body": issue_body})
+                    response, trace = invoke_with_trace(
+                        chain,
+                        {"issue_body": issue_body},
+                        operation="issue_formatter",
+                    )
                 except Exception as e:
                     # If GitHub Models fails with 401, retry with OpenAI
                     if provider == "github-models" and _is_github_models_auth_error(e):
@@ -515,7 +522,11 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
                         if fallback_info:
                             client, provider = fallback_info
                             chain = template | client
-                            response = chain.invoke({"issue_body": issue_body})
+                            response, trace = invoke_with_trace(
+                                chain,
+                                {"issue_body": issue_body},
+                                operation="issue_formatter",
+                            )
                         else:
                             raise
                     else:
@@ -528,12 +539,14 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
                     # splitting here - it causes task explosion (issue #805, #1143).
                     formatted, audit = _validate_and_refine_tasks(formatted, use_llm=use_llm)
                     formatted = _append_raw_issue_section(formatted, issue_body)
-                    return {
+                    result = {
                         "formatted_body": formatted,
                         "provider_used": provider,
                         "used_llm": True,
                         "validation_audit": audit,
                     }
+                    result.update(trace.as_dict())
+                    return result
             except ImportError:
                 # Fall through to fallback if imports fail
                 pass
@@ -592,6 +605,10 @@ def main() -> None:
         if result.get("guard_blocked"):
             payload["guard_blocked"] = True
             payload["guard_reason"] = result.get("guard_reason") or ""
+        if result.get("langsmith_trace_id"):
+            payload["langsmith_trace_id"] = result["langsmith_trace_id"]
+        if result.get("langsmith_trace_url"):
+            payload["langsmith_trace_url"] = result["langsmith_trace_url"]
         print(json.dumps(payload, ensure_ascii=True))
     else:
         print(result["formatted_body"])

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -1267,6 +1267,10 @@ def main() -> None:
             if result.get("guard_blocked"):
                 payload["guard_blocked"] = True
                 payload["guard_reason"] = result.get("guard_reason") or ""
+            if result.get("langsmith_trace_id"):
+                payload["langsmith_trace_id"] = result["langsmith_trace_id"]
+            if result.get("langsmith_trace_url"):
+                payload["langsmith_trace_url"] = result["langsmith_trace_url"]
             print(json.dumps(payload, ensure_ascii=True))
         else:
             print(result["formatted_body"])

--- a/scripts/langchain/issue_pr_context.py
+++ b/scripts/langchain/issue_pr_context.py
@@ -60,9 +60,11 @@ def estimate_tokens(text: str, *, model: str | None = None) -> int:
         encoding = (
             tiktoken.encoding_for_model(model) if model else tiktoken.get_encoding("cl100k_base")
         )
+        return max(len(encoding.encode(value)), chars_estimate)
     except Exception:
-        encoding = tiktoken.get_encoding("cl100k_base")
-    return max(len(encoding.encode(value)), chars_estimate)
+        # tiktoken may need to download encoding metadata on first use; fall back
+        # to the chars-based estimate when network access is unavailable.
+        return chars_estimate
 
 
 def build_issue_context(

--- a/scripts/langchain/structured_output.py
+++ b/scripts/langchain/structured_output.py
@@ -7,6 +7,11 @@ from typing import Any, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
+try:
+    from scripts.langchain.trace_utils import invoke_with_trace
+except ModuleNotFoundError:
+    from trace_utils import invoke_with_trace
+
 T = TypeVar("T", bound=BaseModel)
 
 
@@ -70,7 +75,10 @@ def build_repair_prompt(
 
 
 def build_repair_callback(
-    client: Any, *, template: str = DEFAULT_REPAIR_PROMPT
+    client: Any,
+    *,
+    template: str = DEFAULT_REPAIR_PROMPT,
+    operation: str = "structured_output_repair",
 ) -> Callable[[str, str, str], str | None]:
     def _repair(schema_json: str, validation_errors: str, raw_response: str) -> str | None:
         try:
@@ -80,7 +88,11 @@ def build_repair_callback(
                 raw_response=raw_response,
                 template=template,
             )
-            response = client.invoke(repair_prompt)
+            response, _trace = invoke_with_trace(
+                client,
+                repair_prompt,
+                operation=operation,
+            )
         except Exception:
             return None
         return getattr(response, "content", None) or str(response)

--- a/scripts/langchain/task_decomposer.py
+++ b/scripts/langchain/task_decomposer.py
@@ -15,6 +15,11 @@ import re
 from pathlib import Path
 from typing import Any
 
+try:
+    from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
+except ModuleNotFoundError:
+    from trace_utils import TraceInfo, invoke_with_trace
+
 TASK_DECOMPOSITION_PROMPT = """
 This task is too large for a single agent iteration (~10 minutes):
 
@@ -530,8 +535,13 @@ def decompose_task(task: str, *, use_llm: bool = True) -> dict[str, Any]:
                 prompt = _load_prompt()
                 template = ChatPromptTemplate.from_template(prompt)
                 chain = template | client
+                trace = TraceInfo()
                 try:
-                    response = chain.invoke({"large_task": task})
+                    response, trace = invoke_with_trace(
+                        chain,
+                        {"large_task": task},
+                        operation="task_decomposer",
+                    )
                 except Exception as e:
                     # If GitHub Models fails with 401, retry with OpenAI
                     if provider == "github-models" and _is_github_models_auth_error(e):
@@ -539,7 +549,11 @@ def decompose_task(task: str, *, use_llm: bool = True) -> dict[str, Any]:
                         if fallback_info:
                             client, provider = fallback_info
                             chain = template | client
-                            response = chain.invoke({"large_task": task})
+                            response, trace = invoke_with_trace(
+                                chain,
+                                {"large_task": task},
+                                operation="task_decomposer",
+                            )
                         else:
                             raise
                     else:
@@ -547,11 +561,13 @@ def decompose_task(task: str, *, use_llm: bool = True) -> dict[str, Any]:
                 content = getattr(response, "content", None) or str(response)
                 sub_tasks = _normalize_subtasks(_parse_subtasks(content))
                 if sub_tasks:
-                    return {
+                    result = {
                         "sub_tasks": sub_tasks,
                         "provider_used": provider,
                         "used_llm": True,
                     }
+                    result.update(trace.as_dict())
+                    return result
 
     return {
         "sub_tasks": _normalize_subtasks(_fallback_decompose(task)),

--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -1,0 +1,672 @@
+#!/usr/bin/env python3
+"""
+Two-pass task validation: heuristic triage + LLM refinement.
+
+This module ensures tasks are actionable and acceptance criteria are verifiable
+by flagging questionable items and asking the LLM to refine them.
+
+Run with:
+    python scripts/langchain/task_validator.py --tasks "task1" "task2" --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+try:
+    from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
+except ModuleNotFoundError:
+    from trace_utils import TraceInfo, invoke_with_trace
+
+# ---------------------------------------------------------------------------
+# Constants for heuristic detection
+# ---------------------------------------------------------------------------
+
+# Subjective words that need measurable context
+SUBJECTIVE_WORDS = (
+    "clean",
+    "nice",
+    "good",
+    "better",
+    "intuitive",
+    "polished",
+    "quality",
+    "appropriate",
+    "adequate",
+    "sufficient",
+    "proper",
+    "properly",
+    "correctly",
+    "ensure",
+)
+
+# Words that indicate measurable verification
+MEASURABLE_WORDS = (
+    "test",
+    "tests",
+    "pass",
+    "passes",
+    "fail",
+    "lint",
+    "ci",
+    "coverage",
+    "exists",
+    "returns",
+    "outputs",
+    "contains",
+    "count",
+    "number",
+    "error",
+    "errors",
+)
+
+# Human-only activity indicators
+HUMAN_ACTIVITY_PATTERNS = (
+    r"\b(train|training)\s+(staff|team|employees|personnel)\b",
+    r"\b(conduct|hold|schedule)\s+(session|meeting|interview|review)\b",
+    r"\b(obtain|gather|collect)\s+(feedback|input|approval)\b",
+    r"\b(stakeholder|staff\s+member|employee)\b",
+    r"\bpeer\s+review\b",
+    r"\bmanual\s+review\b",
+)
+
+# Recursive expansion prefixes that indicate already-processed tasks
+EXPANSION_PREFIXES = (
+    "define scope for:",
+    "implement focused slice for:",
+    "validate focused slice for:",
+    "define approach for:",
+)
+
+PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "refine_tasks.md"
+
+REFINEMENT_PROMPT = """
+The following tasks/criteria were flagged as potentially problematic.
+For each item, decide:
+
+1. **KEEP** - If it's actually valid and actionable, output it unchanged
+2. **IMPROVE** - Rewrite to be specific, actionable, and verifiable
+3. **DROP** - If it's not a coding task (header, human activity, fragment)
+
+Issue context:
+{context}
+
+Flagged items:
+{flagged_items}
+
+For each item, respond with EXACTLY one line in this format:
+- KEEP: <original task unchanged>
+- IMPROVE: <rewritten task>
+- DROP: <brief reason>
+
+A valid task MUST be something a coding agent can complete:
+- Creates, modifies, or deletes code/config/docs
+- Has a verifiable outcome (tests pass, file exists, lint clean)
+- NOT: human activities, meetings, reviews, subjective quality checks
+
+Process each item in order. Do not skip any items.
+""".strip()
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+class TaskOutcome(StrEnum):
+    """Possible outcomes for a flagged task."""
+
+    KEPT = "kept"
+    IMPROVED = "improved"
+    DROPPED = "dropped"
+    UNPROCESSED = "unprocessed"  # LLM didn't respond; kept original
+
+
+@dataclass
+class TaskFate:
+    """Tracks what happened to a task through validation."""
+
+    original: str
+    outcome: TaskOutcome
+    result: str | None  # None only for dropped
+    reason: str | None = None  # Why dropped/improved/unprocessed
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "original": self.original,
+            "outcome": self.outcome.value,
+            "result": self.result,
+            "reason": self.reason,
+            "warnings": self.warnings,
+        }
+
+
+@dataclass
+class ValidationResult:
+    """Complete result of task validation."""
+
+    tasks: list[str]
+    fates: list[TaskFate]
+    audit_summary: str
+    provider_used: str | None = None
+    langsmith_trace_id: str | None = None
+    langsmith_trace_url: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "tasks": self.tasks,
+            "fates": [f.to_dict() for f in self.fates],
+            "audit_summary": self.audit_summary,
+            "provider_used": self.provider_used,
+        }
+        if self.langsmith_trace_id:
+            payload["langsmith_trace_id"] = self.langsmith_trace_id
+        if self.langsmith_trace_url:
+            payload["langsmith_trace_url"] = self.langsmith_trace_url
+        return payload
+
+
+# ---------------------------------------------------------------------------
+# Heuristic detection functions
+# ---------------------------------------------------------------------------
+
+
+def _has_subjective_without_measurable(task: str) -> bool:
+    """Check if task has subjective language without measurable verification."""
+    lowered = task.lower()
+    has_subjective = any(word in lowered for word in SUBJECTIVE_WORDS)
+    has_measurable = any(word in lowered for word in MEASURABLE_WORDS)
+    return has_subjective and not has_measurable
+
+
+def _looks_like_human_activity(task: str) -> bool:
+    """Check if task describes human-only activity."""
+    return any(re.search(pattern, task, re.IGNORECASE) for pattern in HUMAN_ACTIVITY_PATTERNS)
+
+
+def _has_expansion_prefix(task: str) -> bool:
+    """Check if task has recursive expansion prefix."""
+    lowered = task.lower().strip()
+    return any(lowered.startswith(prefix) for prefix in EXPANSION_PREFIXES)
+
+
+def _is_punctuation_fragment(task: str) -> bool:
+    """Check if task is just punctuation or whitespace fragments."""
+    cleaned = re.sub(r"[\s,;:.!?()[\]{}\"'`]+", "", task)
+    return len(cleaned) < 3
+
+
+def _is_header_syntax(task: str) -> bool:
+    """Check if task is actually a markdown header."""
+    return bool(re.match(r"^\s*#{1,6}\s+", task.strip()))
+
+
+def _is_too_short(task: str) -> bool:
+    """Check if task is too short to be meaningful."""
+    words = task.split()
+    return len(words) < 4
+
+
+# Warning signal registry
+WARNING_SIGNALS: dict[str, Any] = {
+    "too_short": _is_too_short,
+    "is_header": _is_header_syntax,
+    "subjective_language": _has_subjective_without_measurable,
+    "human_activity": _looks_like_human_activity,
+    "recursive_prefix": _has_expansion_prefix,
+    "punctuation_fragment": _is_punctuation_fragment,
+}
+
+
+# ---------------------------------------------------------------------------
+# Triage functions
+# ---------------------------------------------------------------------------
+
+
+def triage_tasks(tasks: list[str]) -> dict[str, list[Any]]:
+    """
+    Separate tasks into clean vs flagged for review.
+
+    Args:
+        tasks: List of task strings to triage
+
+    Returns:
+        Dictionary with "clean" (list[str]) and "flagged" (list[dict]) keys
+    """
+    clean: list[str] = []
+    flagged: list[dict[str, Any]] = []
+
+    for task in tasks:
+        if not task or not task.strip():
+            continue
+
+        warnings = [name for name, check in WARNING_SIGNALS.items() if check(task)]
+
+        if warnings:
+            flagged.append({"task": task, "warnings": warnings})
+        else:
+            clean.append(task)
+
+    return {"clean": clean, "flagged": flagged}
+
+
+# ---------------------------------------------------------------------------
+# LLM client utilities
+# ---------------------------------------------------------------------------
+
+
+def _get_llm_client(force_openai: bool = False) -> tuple[object, str] | None:
+    """Get LLM client using slot order (OpenAI, Claude, GitHub Models)."""
+    try:
+        from tools.langchain_client import build_chat_client
+    except ImportError:
+        return None
+
+    resolved = build_chat_client(provider="openai" if force_openai else None)
+    if not resolved:
+        return None
+    return resolved.client, resolved.provider
+
+
+def _is_github_models_auth_error(exc: Exception) -> bool:
+    """Check if exception is a GitHub Models authentication error."""
+    exc_str = str(exc).lower()
+    return "401" in exc_str and "models" in exc_str
+
+
+def _load_refinement_prompt() -> str:
+    """Load refinement prompt from file or use default."""
+    if PROMPT_PATH.is_file():
+        return PROMPT_PATH.read_text(encoding="utf-8").strip()
+    return REFINEMENT_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+# Pattern to match KEEP/IMPROVE/DROP responses
+REFINEMENT_PATTERN = re.compile(r"^\s*[-*]?\s*(KEEP|IMPROVE|DROP)\s*:\s*(.+)$", re.IGNORECASE)
+
+
+def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> list[TaskFate]:
+    """
+    Parse LLM refinement response into TaskFate objects.
+
+    Falls back to keeping original if parsing fails for any item.
+    """
+    fates: list[TaskFate] = []
+    response_lines = [line.strip() for line in response.splitlines() if line.strip()]
+
+    # Track which flagged items we've processed
+    processed_indices: set[int] = set()
+
+    # Try to match response lines to flagged items in order
+    line_idx = 0
+    for item_idx, item in enumerate(flagged):
+        task = item["task"]
+        warnings = item.get("warnings", [])
+
+        # Look for a matching response line
+        fate: TaskFate | None = None
+
+        while line_idx < len(response_lines):
+            line = response_lines[line_idx]
+            match = REFINEMENT_PATTERN.match(line)
+
+            if match:
+                action = match.group(1).upper()
+                content = match.group(2).strip()
+
+                if action == "KEEP":
+                    fate = TaskFate(
+                        original=task,
+                        outcome=TaskOutcome.KEPT,
+                        result=task,  # Keep original text
+                        reason="LLM confirmed valid",
+                        warnings=warnings,
+                    )
+                elif action == "IMPROVE":
+                    fate = TaskFate(
+                        original=task,
+                        outcome=TaskOutcome.IMPROVED,
+                        result=content,
+                        reason="LLM improved for actionability",
+                        warnings=warnings,
+                    )
+                elif action == "DROP":
+                    fate = TaskFate(
+                        original=task,
+                        outcome=TaskOutcome.DROPPED,
+                        result=None,
+                        reason=content,
+                        warnings=warnings,
+                    )
+
+                line_idx += 1
+                processed_indices.add(item_idx)
+                break
+            else:
+                # Skip non-matching lines
+                line_idx += 1
+
+        # If no fate assigned, keep original (fallback)
+        if fate is None:
+            fate = TaskFate(
+                original=task,
+                outcome=TaskOutcome.UNPROCESSED,
+                result=task,
+                reason="LLM did not respond; keeping original",
+                warnings=warnings,
+            )
+
+        fates.append(fate)
+
+    return fates
+
+
+# ---------------------------------------------------------------------------
+# Main refinement function
+# ---------------------------------------------------------------------------
+
+
+def refine_flagged_tasks(
+    flagged: list[dict[str, Any]], context: str = ""
+) -> tuple[list[str], list[TaskFate], str | None, TraceInfo]:
+    """
+    Send flagged tasks to LLM for refinement decision.
+
+    Args:
+        flagged: List of {"task": str, "warnings": list[str]} dicts
+        context: Optional issue context for LLM
+
+    Returns:
+        Tuple of (refined_tasks, fates, provider_used, trace_info)
+    """
+    if not flagged:
+        return [], [], None, TraceInfo()
+
+    # Format flagged items for prompt
+    flagged_lines: list[str] = []
+    for i, item in enumerate(flagged, 1):
+        task = item["task"]
+        warnings = item.get("warnings", [])
+        warning_text = f" (warnings: {', '.join(warnings)})" if warnings else ""
+        flagged_lines.append(f"{i}. {task}{warning_text}")
+
+    flagged_text = "\n".join(flagged_lines)
+
+    # Try to get LLM client
+    client_info = _get_llm_client()
+    if not client_info:
+        # No LLM available - return originals with unprocessed fates
+        fates = [
+            TaskFate(
+                original=item["task"],
+                outcome=TaskOutcome.UNPROCESSED,
+                result=item["task"],
+                reason="No LLM available; keeping original",
+                warnings=item.get("warnings", []),
+            )
+            for item in flagged
+        ]
+        tasks = [f.result for f in fates if f.result]
+        return tasks, fates, None, TraceInfo()
+
+    client, provider = client_info
+
+    try:
+        from langchain_core.prompts import ChatPromptTemplate
+    except ImportError:
+        # Fallback without LangChain
+        fates = [
+            TaskFate(
+                original=item["task"],
+                outcome=TaskOutcome.UNPROCESSED,
+                result=item["task"],
+                reason="LangChain unavailable; keeping original",
+                warnings=item.get("warnings", []),
+            )
+            for item in flagged
+        ]
+        tasks = [f.result for f in fates if f.result]
+        return tasks, fates, None, TraceInfo()
+
+    # Build and invoke prompt
+    prompt_template = _load_refinement_prompt()
+    template = ChatPromptTemplate.from_template(prompt_template)
+    chain = template | client
+    trace = TraceInfo()
+
+    try:
+        response, trace = invoke_with_trace(
+            chain,
+            {"flagged_items": flagged_text, "context": context or "None"},
+            operation="task_validator",
+        )
+    except Exception as e:
+        # If GitHub Models fails, try OpenAI
+        if provider == "github-models" and _is_github_models_auth_error(e):
+            fallback_info = _get_llm_client(force_openai=True)
+            if fallback_info:
+                client, provider = fallback_info
+                chain = template | client
+                response, trace = invoke_with_trace(
+                    chain,
+                    {"flagged_items": flagged_text, "context": context or "None"},
+                    operation="task_validator",
+                )
+            else:
+                raise
+        else:
+            raise
+
+    # Parse response
+    content = getattr(response, "content", None) or str(response)
+    fates = _parse_refinement_response(content, flagged)
+
+    # Extract tasks (non-None results)
+    tasks = [f.result for f in fates if f.result is not None]
+
+    return tasks, fates, provider, trace
+
+
+# ---------------------------------------------------------------------------
+# Audit and merge functions
+# ---------------------------------------------------------------------------
+
+
+def validate_no_items_lost(
+    original_count: int,
+    result_count: int,
+    dropped_count: int,
+) -> None:
+    """
+    Raise ValueError if items disappeared without explicit DROP.
+
+    Args:
+        original_count: Number of input items
+        result_count: Number of items in final output
+        dropped_count: Number of items explicitly dropped
+    """
+    accounted = result_count + dropped_count
+    if accounted < original_count:
+        missing = original_count - accounted
+        raise ValueError(
+            f"Item loss detected: {original_count} input, {accounted} accounted for "
+            f"({result_count} kept/improved, {dropped_count} dropped). "
+            f"{missing} items unaccounted for."
+        )
+
+
+def merge_with_audit(
+    clean: list[str],
+    refined: list[str],
+    fates: list[TaskFate],
+    original_count: int,
+) -> tuple[list[str], str]:
+    """
+    Merge clean and refined tasks, returning audit summary.
+
+    Args:
+        clean: Tasks that passed heuristic checks
+        refined: Tasks from LLM refinement
+        fates: TaskFate objects from refinement
+        original_count: Original number of input tasks
+
+    Returns:
+        Tuple of (final_tasks, audit_summary)
+    """
+    final = clean + refined
+
+    # Count outcomes
+    dropped = [f for f in fates if f.outcome == TaskOutcome.DROPPED]
+    improved = [f for f in fates if f.outcome == TaskOutcome.IMPROVED]
+    kept = [f for f in fates if f.outcome == TaskOutcome.KEPT]
+    unprocessed = [f for f in fates if f.outcome == TaskOutcome.UNPROCESSED]
+
+    # Validate no silent loss
+    # Clean items + all fates should equal original count
+    accounted = len(clean) + len(fates)
+    if accounted != original_count:
+        raise ValueError(
+            f"Audit mismatch: {original_count} input items, "
+            f"but {len(clean)} clean + {len(fates)} fates = {accounted}"
+        )
+
+    # Validate no result loss
+    validate_no_items_lost(
+        original_count=original_count,
+        result_count=len(final),
+        dropped_count=len(dropped),
+    )
+
+    audit = (
+        f"Task validation: {original_count} input → {len(final)} output. "
+        f"Clean: {len(clean)}, Kept: {len(kept)}, Improved: {len(improved)}, "
+        f"Dropped: {len(dropped)}, Fallback: {len(unprocessed)}"
+    )
+
+    return final, audit
+
+
+# ---------------------------------------------------------------------------
+# Main validation function
+# ---------------------------------------------------------------------------
+
+
+def validate_tasks(
+    tasks: list[str],
+    context: str = "",
+    *,
+    use_llm: bool = True,
+) -> ValidationResult:
+    """
+    Validate tasks using two-pass heuristic + LLM approach.
+
+    Args:
+        tasks: List of task strings to validate
+        context: Optional issue context for LLM refinement
+        use_llm: Whether to use LLM for refinement (default True)
+
+    Returns:
+        ValidationResult with final tasks and full audit trail
+    """
+    tasks = [task for task in tasks if task and task.strip()]
+
+    if not tasks:
+        return ValidationResult(
+            tasks=[],
+            fates=[],
+            audit_summary="No tasks to validate",
+            provider_used=None,
+        )
+
+    original_count = len(tasks)
+
+    # Pass 1: Heuristic triage
+    triage_result = triage_tasks(tasks)
+    clean = triage_result["clean"]
+    flagged = triage_result["flagged"]
+
+    # If nothing flagged, return clean tasks
+    if not flagged:
+        return ValidationResult(
+            tasks=clean,
+            fates=[],
+            audit_summary=f"Task validation: {original_count} input → {len(clean)} output. All clean.",
+            provider_used=None,
+        )
+
+    # Pass 2: LLM refinement (if enabled)
+    if use_llm:
+        refined, fates, provider, trace = refine_flagged_tasks(flagged, context)
+    else:
+        # No LLM - keep all flagged items as unprocessed
+        fates = [
+            TaskFate(
+                original=item["task"],
+                outcome=TaskOutcome.UNPROCESSED,
+                result=item["task"],
+                reason="LLM disabled; keeping original",
+                warnings=item.get("warnings", []),
+            )
+            for item in flagged
+        ]
+        refined = [f.result for f in fates if f.result]
+        provider = None
+        trace = TraceInfo()
+
+    # Merge and audit
+    final_tasks, audit = merge_with_audit(clean, refined, fates, original_count)
+
+    return ValidationResult(
+        tasks=final_tasks,
+        fates=fates,
+        audit_summary=audit,
+        provider_used=provider,
+        langsmith_trace_id=trace.trace_id,
+        langsmith_trace_url=trace.trace_url,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate tasks for actionability.")
+    parser.add_argument("--tasks", nargs="+", help="Tasks to validate.")
+    parser.add_argument("--context", default="", help="Issue context for refinement.")
+    parser.add_argument("--json", action="store_true", help="Output JSON.")
+    parser.add_argument("--no-llm", action="store_true", help="Disable LLM refinement.")
+    args = parser.parse_args()
+
+    tasks = args.tasks or []
+    result = validate_tasks(tasks, args.context, use_llm=not args.no_llm)
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2))
+    else:
+        print(f"Audit: {result.audit_summary}")
+        print("\nFinal tasks:")
+        for task in result.tasks:
+            print(f"  - {task}")
+        if result.fates:
+            print("\nFates:")
+            for fate in result.fates:
+                print(f"  [{fate.outcome.value}] {fate.original[:50]}...")
+                if fate.reason:
+                    print(f"    Reason: {fate.reason}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/langchain/topic_splitter.py
+++ b/scripts/langchain/topic_splitter.py
@@ -20,6 +20,11 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+try:
+    from scripts.langchain.trace_utils import invoke_with_trace
+except ModuleNotFoundError:
+    from trace_utils import invoke_with_trace
+
 TOPIC_SPLITTER_PROMPT = """
 You are a text parsing assistant. The input contains one or more GitHub issues
 or feature requests. Your job is to split them into separate, individual issues.
@@ -94,7 +99,9 @@ def split_topics_with_llm(input_text: str) -> list[dict[str, Any]]:
     prompt = TOPIC_SPLITTER_PROMPT.format(input_text=input_text)
 
     try:
-        response = llm.invoke(prompt)
+        response, trace = invoke_with_trace(llm, prompt, operation="topic_splitter")
+        if trace.trace_url:
+            print(f"LangSmith trace: {trace.trace_url}", file=sys.stderr)
         content = response.content if hasattr(response, "content") else str(response)
     except Exception as e:
         raise RuntimeError(f"LLM call failed: {e}") from e

--- a/scripts/langchain/trace_utils.py
+++ b/scripts/langchain/trace_utils.py
@@ -1,0 +1,126 @@
+"""Small LangSmith tracing helpers for LangChain script entry points."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TraceInfo:
+    """Trace metadata extracted from a LangChain response."""
+
+    trace_id: str | None = None
+    trace_url: str | None = None
+
+    @property
+    def available(self) -> bool:
+        return bool(self.trace_id or self.trace_url)
+
+    def as_dict(self) -> dict[str, str]:
+        payload: dict[str, str] = {}
+        if self.trace_id:
+            payload["langsmith_trace_id"] = self.trace_id
+        if self.trace_url:
+            payload["langsmith_trace_url"] = self.trace_url
+        return payload
+
+
+def build_trace_config(
+    *,
+    operation: str,
+    pr_number: int | None = None,
+    issue_number: int | None = None,
+) -> dict[str, object]:
+    """Build standard LangSmith config for a LangChain invocation."""
+
+    try:
+        from tools.llm_provider import build_langsmith_metadata
+
+        return build_langsmith_metadata(
+            operation=operation,
+            pr_number=pr_number,
+            issue_number=issue_number,
+        )
+    except Exception:
+        metadata = {
+            "operation": operation,
+            "pr_number": str(pr_number) if pr_number is not None else None,
+            "issue_number": str(issue_number) if issue_number is not None else None,
+        }
+        return {"metadata": metadata, "tags": [f"operation:{operation}"]}
+
+
+def extract_trace_info(response: Any) -> TraceInfo:
+    """Extract trace ID and URL from a LangChain response when available."""
+
+    try:
+        from tools.llm_provider import derive_langsmith_trace_url, extract_trace_id
+
+        trace_id = extract_trace_id(response)
+        trace_url = derive_langsmith_trace_url(trace_id) if trace_id else None
+        return TraceInfo(trace_id=trace_id, trace_url=trace_url)
+    except Exception:
+        LOGGER.debug("LangSmith trace extraction unavailable", exc_info=True)
+        return TraceInfo()
+
+
+def _invoke_accepts_config(invoke: Any) -> bool:
+    try:
+        signature = inspect.signature(invoke)
+    except (TypeError, ValueError):
+        return True
+
+    for param in signature.parameters.values():
+        if param.name == "config" or param.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+    return False
+
+
+def _is_unsupported_config_error(exc: TypeError) -> bool:
+    message = str(exc)
+    return "config" in message and (
+        "unexpected keyword argument" in message
+        or "got an unexpected keyword" in message
+        or "positional-only" in message
+    )
+
+
+def invoke_with_trace(
+    runnable: Any,
+    payload: Any,
+    *,
+    operation: str,
+    pr_number: int | None = None,
+    issue_number: int | None = None,
+) -> tuple[Any, TraceInfo]:
+    """Invoke a LangChain runnable with metadata and return trace details.
+
+    Some older local tests and provider shims do not accept a ``config=``
+    argument. In that case, retry once without config while still extracting
+    trace details if the provider response exposes them.
+    """
+
+    config = build_trace_config(
+        operation=operation,
+        pr_number=pr_number,
+        issue_number=issue_number,
+    )
+    invoke = runnable.invoke
+    if _invoke_accepts_config(invoke):
+        try:
+            response = invoke(payload, config=config)
+        except TypeError as exc:
+            if not _is_unsupported_config_error(exc):
+                raise
+            response = invoke(payload)
+    else:
+        response = invoke(payload)
+    trace = extract_trace_info(response)
+    if trace.trace_url:
+        LOGGER.info("LangSmith trace: %s", trace.trace_url)
+    return response, trace


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-auto-pilot.yml: Auto-pilot - end-to-end automation orchestrator (format → optimize → agent → verify)
- aggregate_agent_metrics.py: Aggregates downloaded weekly agent metrics - required by agents-weekly-metrics.yml
- bot_comment_auth_coverage.js: Warning-only bot-comment App auth coverage preflight
- issue_optimizer.py: Issue optimizer - analyzes issues and suggests improvements
- structured_output.py: Shared structured output helpers for LangChain workflows
- trace_utils.py: Shared LangSmith trace metadata helpers for LangChain workflows
- issue_formatter.py: Issue formatter - converts raw text to AGENT_ISSUE_TEMPLATE format
- issue_pr_context.py: Issue/PR context assembly helper with shared token budget caps
- context_extractor.py: Context extractor - extracts relevant context from issues/PRs
- task_decomposer.py: Task decomposer - breaks large issues into sub-tasks
- task_validator.py: Task validator - refines generated issue tasks for actionability
- topic_splitter.py: Topic splitter - splits conversations into discrete issues

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `12d843158dd8bc41e9a72ede3c9430264ebc3bbe`
**Template hash:** `b877a6283fa6`
**Sync branch:** `sync/workflows-b877a6283fa6`
**Consumer repo:** `stranske/Collab-Admin`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Collab-Admin","source_repository":"stranske/Workflows","source_sha":"12d843158dd8bc41e9a72ede3c9430264ebc3bbe","template_hash":"b877a6283fa6","sync_branch":"sync/workflows-b877a6283fa6","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"25926572034","run_attempt":"1","changes_count":12} -->