### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,11 +5,11 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.19
+RUFF_VERSION=0.16.3
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
-MYPY_VERSION=2.1.0
+MYPY_VERSION=2.3.0
 PYTEST_VERSION=9.1.1
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.14.3
+COVERAGE_VERSION=7.15.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
 dev = [
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
-    "ruff==0.15.19",
-    "mypy>=2.1.0",
+    "ruff==0.16.3",
+    "mypy==2.3.0",
     "black==26.5.1",
 ]
 

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,7 +10,7 @@ attrs==25.4.0
     # via
     #   jsonschema
     #   referencing
-black==26.3.1
+black==26.5.1
     # via collab-admin (pyproject.toml)
 blinker==1.9.0
     # via streamlit
@@ -24,7 +24,7 @@ click==8.3.1
     # via
     #   black
     #   streamlit
-coverage==7.13.0
+coverage==7.15.4
     # via pytest-cov
 gitdb==4.0.12
     # via gitpython
@@ -46,7 +46,7 @@ librt==0.10.0
     # via mypy
 markupsafe==3.0.3
     # via jinja2
-mypy==2.0.0
+mypy==2.3.0
     # via collab-admin (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -89,7 +89,7 @@ pydeck==0.9.1
     # via streamlit
 pygments==2.19.2
     # via pytest
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   collab-admin (pyproject.toml)
     #   pytest-cov
@@ -115,7 +115,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.12
+ruff==0.16.3
     # via collab-admin (pyproject.toml)
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 7 version updates:
  - ruff: ==0.15.19 -> ==0.16.3
  - mypy: >=2.1.0 -> ==2.3.0
  - requirements-dev.lock:black: 26.3.1 -> ==26.5.1
  - requirements-dev.lock:coverage: 7.13.0 -> ==7.15.4
  - requirements-dev.lock:mypy: 2.0.0 -> ==2.3.0
  - requirements-dev.lock:pytest: 9.0.3 -> ==9.1.1
  - requirements-dev.lock:ruff: 0.15.12 -> ==0.16.3

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`
**Settled source commit:** `770c226a9eeb22be1dc8e1e33511f8aacd5434a8`

<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"dev-tool-02c0c6e3cd5f","generation":"02c0c6e3cd5f","repository":"stranske/Collab-Admin","desired_tree_hash":"6d447c0947caee52a9bdc5bbd0ca0a6ba803afab","source_commit":"770c226a9eeb22be1dc8e1e33511f8aacd5434a8","lease_expires_at":"2026-08-16T19:28:25Z","predecessor_prs":[],"successor_prs":[]} -->